### PR TITLE
Fixing CraftModel for GPU acceleration

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,14 +246,14 @@ try (var classifier = ResNetClassifier.builder()
 
 The `.sessionOptions()` API is available on every model wrapper.
 
-### Benchmark: ResNet-50 on Apple Silicon (M-series)
+### Benchmarks on Apple Silicon (M-series)
 
-| Provider | Avg Inference | Speedup |
-|----------|--------------|---------|
-| CPU      | 37 ms        | —       |
-| CoreML   | 10 ms        | **3.7x** |
+| Model | Task | CPU | CoreML | Speedup |
+|-------|------|-----|--------|---------|
+| ResNet-50 | Image Classification | 37 ms | 10 ms | **3.7x** |
+| CRAFT | Text Detection | 831 ms | 153 ms | **5.4x** |
 
-> Measured with 3 warmup runs + 10 timed runs. See [`ResNetAccelerationBenchmarkExample`](inference4j-examples/src/main/java/io/github/inference4j/examples/ResNetAccelerationBenchmarkExample.java) for the full benchmark.
+> Measured with 3 warmup runs + 10 timed runs. See the benchmark examples for [ResNet](inference4j-examples/src/main/java/io/github/inference4j/examples/ResNetAccelerationBenchmarkExample.java) and [CRAFT](inference4j-examples/src/main/java/io/github/inference4j/examples/CraftAccelerationBenchmarkExample.java).
 
 ## Roadmap
 

--- a/inference4j-core/src/main/java/io/github/inference4j/HuggingFaceModelSource.java
+++ b/inference4j-core/src/main/java/io/github/inference4j/HuggingFaceModelSource.java
@@ -66,7 +66,7 @@ public class HuggingFaceModelSource implements ModelSource {
     private static final String HF_BASE_URL = "https://huggingface.co";
 
     private static final List<String> DEFAULT_FILES = List.of(
-            "model.onnx", "model.onnx.data", "vocab.txt", "vocab.json",
+            "model.onnx", "vocab.txt", "vocab.json",
             "config.json", "labels.txt", "silero_vad.onnx"
     );
 

--- a/inference4j-examples/src/main/java/io/github/inference4j/examples/CraftAccelerationBenchmarkExample.java
+++ b/inference4j-examples/src/main/java/io/github/inference4j/examples/CraftAccelerationBenchmarkExample.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.inference4j.examples;
+
+import io.github.inference4j.SessionConfigurer;
+import io.github.inference4j.vision.CraftTextDetector;
+import io.github.inference4j.vision.TextRegion;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Benchmarks CRAFT text detection across execution providers: CPU, CoreML (macOS), CUDA.
+ *
+ * <p>Run with:
+ * <pre>
+ * ./gradlew :inference4j-examples:run -PmainClass=io.github.inference4j.examples.CraftAccelerationBenchmarkExample
+ * </pre>
+ */
+public class CraftAccelerationBenchmarkExample {
+
+	private static final Path IMAGE_PATH = Path.of("assets/images/product_placement.jpg");
+	private static final int WARMUP_RUNS = 3;
+	private static final int TIMED_RUNS = 10;
+
+	public static void main(String[] args) throws IOException {
+		System.out.println("=== CRAFT Text Detection — Execution Provider Benchmark ===");
+		System.out.println("Image: " + IMAGE_PATH);
+		System.out.printf("Warmup runs: %d, Timed runs: %d%n", WARMUP_RUNS, TIMED_RUNS);
+
+		long cpuAvgMs = runProvider("CPU", null);
+
+		long coremlAvgMs = runProvider("CoreML", opts -> opts.addCoreML());
+
+		long cudaAvgMs = runProvider("CUDA", opts -> opts.addCUDA(0));
+
+		// --- Summary ---
+		System.out.println("\n=== Summary ===");
+		printRow("CPU", cpuAvgMs);
+		printRow("CoreML", coremlAvgMs);
+		printRow("CUDA", cudaAvgMs);
+
+		if (cpuAvgMs > 0) {
+			if (coremlAvgMs > 0) {
+				System.out.printf("  CoreML speedup: %.2fx%n", (double) cpuAvgMs / coremlAvgMs);
+			}
+			if (cudaAvgMs > 0) {
+				System.out.printf("  CUDA speedup:   %.2fx%n", (double) cpuAvgMs / cudaAvgMs);
+			}
+		}
+	}
+
+	private static long runProvider(String name, SessionConfigurer configurer) throws IOException {
+		System.out.printf("%n--- %s ---%n", name);
+		try {
+			CraftTextDetector.Builder builder = CraftTextDetector.builder();
+			if (configurer != null) {
+				builder.sessionOptions(configurer);
+			}
+
+			long loadStart = System.nanoTime();
+			try (CraftTextDetector craft = builder.build()) {
+				long loadMs = (System.nanoTime() - loadStart) / 1_000_000;
+				System.out.printf("Model loaded in %d ms%n", loadMs);
+
+				long avgMs = benchmark(craft);
+				System.out.printf("Average inference: %d ms%n", avgMs);
+				return avgMs;
+			}
+		}
+		catch (Exception ex) {
+			System.out.printf("%s not available: %s%n", name, ex.getMessage());
+			return -1;
+		}
+	}
+
+	private static long benchmark(CraftTextDetector craft) throws IOException {
+		for (int i = 0; i < WARMUP_RUNS; i++) {
+			List<TextRegion> regions = craft.detect(IMAGE_PATH, 0.4f, 0.3f);
+			System.out.printf("  warmup %d: %d regions detected%n", i + 1, regions.size());
+		}
+
+		long totalNanos = 0;
+		for (int i = 0; i < TIMED_RUNS; i++) {
+			long start = System.nanoTime();
+			List<TextRegion> regions = craft.detect(IMAGE_PATH, 0.4f, 0.3f);
+			long elapsed = System.nanoTime() - start;
+			totalNanos += elapsed;
+			System.out.printf("  run %d: %d ms — %d regions%n", i + 1, elapsed / 1_000_000,
+					regions.size());
+		}
+
+		return (totalNanos / TIMED_RUNS) / 1_000_000;
+	}
+
+	private static void printRow(String name, long avgMs) {
+		if (avgMs > 0) {
+			System.out.printf("  %-8s  Avg inference: %5d ms%n", name, avgMs);
+		}
+		else {
+			System.out.printf("  %-8s  (not available)%n", name);
+		}
+	}
+
+}

--- a/inference4j-preprocessing/src/main/java/io/github/inference4j/image/ImageTransformPipeline.java
+++ b/inference4j-preprocessing/src/main/java/io/github/inference4j/image/ImageTransformPipeline.java
@@ -76,22 +76,6 @@ public class ImageTransformPipeline implements Preprocessor<BufferedImage, Tenso
                 .build();
     }
 
-    /**
-     * EfficientNet preprocessing: resize → centerCrop → normalize((pixel-127)/128).
-     * Outputs NHWC layout.
-     */
-    public static ImageTransformPipeline efficientnet(int size) {
-        float m = 127f / 255f;
-        float s = 128f / 255f;
-        return builder()
-                .resize(size, size)
-                .centerCrop(size, size)
-                .mean(new float[]{m, m, m})
-                .std(new float[]{s, s, s})
-                .layout(ImageLayout.NHWC)
-                .build();
-    }
-
     public static Builder builder() {
         return new Builder();
     }

--- a/inference4j-preprocessing/src/test/java/io/github/inference4j/image/ImageTransformPipelineTest.java
+++ b/inference4j-preprocessing/src/test/java/io/github/inference4j/image/ImageTransformPipelineTest.java
@@ -181,8 +181,14 @@ class ImageTransformPipelineTest {
     }
 
     @Test
-    void efficientnetPreset_producesNHWCShape() {
-        ImageTransformPipeline pipeline = ImageTransformPipeline.efficientnet(224);
+    void nhwcPipeline_producesCorrectShape() {
+        ImageTransformPipeline pipeline = ImageTransformPipeline.builder()
+                .resize(224, 224)
+                .centerCrop(224, 224)
+                .mean(new float[]{127f / 255f, 127f / 255f, 127f / 255f})
+                .std(new float[]{128f / 255f, 128f / 255f, 128f / 255f})
+                .layout(ImageLayout.NHWC)
+                .build();
         BufferedImage image = createTestImage(300, 400);
 
         Tensor tensor = pipeline.transform(image);
@@ -192,9 +198,9 @@ class ImageTransformPipelineTest {
     }
 
     @Test
-    void efficientnetPreset_appliesCorrectNormalization() {
+    void nhwcPipeline_appliesCorrectNormalization() {
         // White image: all channels = 255 → scaled = 1.0
-        // EfficientNet: (pixel - 127) / 128 = (255 - 127) / 128 = 1.0
+        // (pixel - 127) / 128 = (255 - 127) / 128 = 1.0
         // In mean/std terms: (1.0 - 127/255) / (128/255)
         BufferedImage image = new BufferedImage(224, 224, BufferedImage.TYPE_INT_RGB);
         for (int y = 0; y < 224; y++) {
@@ -203,7 +209,11 @@ class ImageTransformPipelineTest {
             }
         }
 
-        ImageTransformPipeline pipeline = ImageTransformPipeline.efficientnet(224);
+        ImageTransformPipeline pipeline = ImageTransformPipeline.builder()
+                .mean(new float[]{127f / 255f, 127f / 255f, 127f / 255f})
+                .std(new float[]{128f / 255f, 128f / 255f, 128f / 255f})
+                .layout(ImageLayout.NHWC)
+                .build();
         Tensor tensor = pipeline.transform(image);
         float[] data = tensor.toFloats();
 


### PR DESCRIPTION
Our Exported Craft Model was split into two files, which is the norm today for pytorch onnx exports, however onnx java has an issue running GPU workfloads like that, worth investigating later, but for now, merging the file into a single model (83MB way less than 2GB limit that causes the decision to sometimes split it)

- Remove efficientnet() preset from ImageTransformPipeline (leaked model-specific knowledge into generic preprocessing utility)
- Remove model.onnx.data from HuggingFace default download list (CRAFT re-exported as single file to fix GPU acceleration)
- Add CRAFT acceleration benchmark example (5.4x CoreML speedup)
- Update README benchmark table with both ResNet and CRAFT results