### PR TITLE
Add snapshot publishing to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,15 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: inference4j/inference4j
 
+      - name: Publish snapshot to Maven Central
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: ./gradlew publishAllPublicationsToMavenCentralRepository
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
+
       - name: Upload test reports
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Publishes `0.1.0-SNAPSHOT` artifacts to Maven Central on every push to `main`
- Only runs after build and tests pass
- Uses `publishAllPublicationsToMavenCentralRepository` (uploads without closing/releasing, appropriate for snapshots)

## Test plan
- [ ] Merge and verify snapshot appears on Maven Central