### PR TITLE
Handle pre-existing GitHub Release in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,12 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
 
-      - name: Create GitHub Release
-        run: gh release create "${{ github.ref_name }}" --generate-notes --title "${{ github.ref_name }}"
+      - name: Create or update GitHub Release
+        run: |
+          if gh release view "${{ github.ref_name }}" &>/dev/null; then
+            echo "Release ${{ github.ref_name }} already exists, skipping creation"
+          else
+            gh release create "${{ github.ref_name }}" --generate-notes --title "${{ github.ref_name }}"
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Fixes release workflow failure when a GitHub Release already exists for the tag
- This happened with v0.2.0: the release was created as a draft and published before the workflow ran, causing `gh release create` to fail with HTTP 422 (`Release.tag_name already exists`)
- Maven Central publish succeeded — only the GitHub Release step failed

## Test plan

- [ ] Next release: verify workflow completes without error whether release is pre-created or not