### PR TITLE
Redesign ClipClassifier as ZeroShotClassifier with per-call labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,9 @@ try (var detector = CraftTextDetector.builder().build()) {
 ### Zero-Shot Image Classification
 
 ```java
-try (var classifier = ClipClassifier.builder()
-        .labels("cat", "dog", "bird", "car")
-        .build()) {
-    List<Classification> results = classifier.classify(Path.of("photo.jpg"));
+try (var classifier = ClipClassifier.builder().build()) {
+    List<Classification> results = classifier.classify(
+            Path.of("photo.jpg"), List.of("cat", "dog", "bird", "car"));
     // [Classification[label=cat, confidence=0.82], ...]
 }
 ```

--- a/docs/guides/tokenizers.md
+++ b/docs/guides/tokenizers.md
@@ -77,10 +77,8 @@ try (var classifier = DistilBertTextClassifier.builder()
 }
 
 // BPE loaded automatically from vocab.json + merges.txt
-try (var classifier = ClipClassifier.builder()
-        .labels("cat", "dog", "bird")
-        .build()) {
-    classifier.classify(Path.of("photo.jpg"));
+try (var classifier = ClipClassifier.builder().build()) {
+    classifier.classify(Path.of("photo.jpg"), List.of("cat", "dog", "bird"));
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,10 +70,9 @@ try (var detector = CraftTextDetector.builder().build()) {
 ### Zero-Shot Image Classification
 
 ```java
-try (var classifier = ClipClassifier.builder()
-        .labels("cat", "dog", "bird", "car")
-        .build()) {
-    List<Classification> results = classifier.classify(Path.of("photo.jpg"));
+try (var classifier = ClipClassifier.builder().build()) {
+    List<Classification> results = classifier.classify(
+            Path.of("photo.jpg"), List.of("cat", "dog", "bird", "car"));
     // [Classification[label=cat, confidence=0.82], ...]
 }
 ```

--- a/docs/reference/api-overview.md
+++ b/docs/reference/api-overview.md
@@ -6,7 +6,7 @@
 
 | Package | Contents |
 |---------|----------|
-| `io.github.inference4j` | Core contracts: `InferenceTask`, `Classifier`, `Detector`, `AbstractInferenceTask`, `Tensor`, `TensorType`, `InferenceSession`, `InferenceContext` |
+| `io.github.inference4j` | Core contracts: `InferenceTask`, `Classifier`, `Detector`, `ZeroShotClassifier`, `ZeroShotInput`, `AbstractInferenceTask`, `Tensor`, `TensorType`, `InferenceSession`, `InferenceContext` |
 | `io.github.inference4j.session` | Session config: `SessionConfigurer`, `SessionOptions` |
 | `io.github.inference4j.model` | Model resolution: `ModelSource`, `HuggingFaceModelSource`, `LocalModelSource` |
 | `io.github.inference4j.processing` | Pre/post-processing: `Preprocessor`, `Postprocessor`, `OutputOperator`, `MathOps` |
@@ -55,6 +55,7 @@ InferenceTask<I, O>                     // run(I) → O, extends AutoCloseable
 ├── Classifier<I, C>                    // classify(I) → List<C>
 │   ├── ImageClassifier                 // classify(BufferedImage/Path) → List<Classification>
 │   └── TextClassifier                  // classify(String) → List<TextClassification>
+├── ZeroShotClassifier<I, C>            // classify(I, List<String>) → List<C>, run(ZeroShotInput<I>) → List<C>
 ├── Detector<I, D>                      // detect(I) → List<D>
 │   ├── ObjectDetector                  // detect(BufferedImage/Path) → List<Detection>
 │   ├── TextDetector                    // detect(BufferedImage/Path) → List<TextRegion>
@@ -75,7 +76,7 @@ Most task wrappers extend `AbstractInferenceTask<I, O>`, which enforces a `final
 
 `InferenceContext<I>` carries data across stages — the original input, preprocessed tensors, and output tensors.
 
-Exceptions: `SileroVadDetector` (stateful hidden state), `MiniLMSearchReranker`, and `ClipTextEncoder` do not extend `AbstractInferenceTask`.
+Exceptions: `SileroVadDetector` (stateful hidden state), `MiniLMSearchReranker`, `ClipClassifier`, and `ClipTextEncoder` do not extend `AbstractInferenceTask`.
 
 ### Generative AI hierarchy
 

--- a/docs/reference/clip-encoders.md
+++ b/docs/reference/clip-encoders.md
@@ -2,7 +2,7 @@
 
 Low-level access to CLIP's vision and text encoders for image-text similarity, visual search, and custom retrieval pipelines.
 
-For zero-shot image classification, use [`ClipClassifier`](../use-cases/visual-search.md) instead — it provides a higher-level `ImageClassifier` API on top of these encoders.
+For zero-shot classification as a single API, see [Visual Search](../use-cases/visual-search.md). For direct encoder access, see below.
 
 ## ClipImageEncoder
 
@@ -69,7 +69,7 @@ try (ClipImageEncoder imageEncoder = ClipImageEncoder.builder().build();
     float[] imageEmb = imageEncoder.encode(ImageIO.read(Path.of("photo.jpg").toFile()));
     float[] textEmb = textEncoder.encode("a photo of a sunset");
 
-    float similarity = dot(imageEmb, textEmb);
+    float similarity = MathOps.dotProduct(imageEmb, textEmb);
     System.out.println("Similarity: " + similarity);
 }
 ```
@@ -89,7 +89,7 @@ float[] queryEmb = textEncoder.encode("a red sports car");
 int bestIdx = 0;
 float bestScore = Float.NEGATIVE_INFINITY;
 for (int i = 0; i < imageEmbeddings.size(); i++) {
-    float score = dot(queryEmb, imageEmbeddings.get(i));
+    float score = MathOps.dotProduct(queryEmb, imageEmbeddings.get(i));
     if (score > bestScore) {
         bestScore = score;
         bestIdx = i;
@@ -99,14 +99,10 @@ for (int i = 0; i < imageEmbeddings.size(); i++) {
 
 ## Dot product helper
 
-Since both encoders produce L2-normalized vectors, the dot product equals cosine similarity:
+Since both encoders produce L2-normalized vectors, the dot product equals cosine similarity. Use `MathOps.dotProduct()` from inference4j-core:
 
 ```java
-static float dot(float[] a, float[] b) {
-    float sum = 0f;
-    for (int i = 0; i < a.length; i++) {
-        sum += a[i] * b[i];
-    }
-    return sum;
-}
+import io.github.inference4j.processing.MathOps;
+
+float similarity = MathOps.dotProduct(imageEmb, textEmb);
 ```

--- a/docs/reference/supported-models.md
+++ b/docs/reference/supported-models.md
@@ -24,7 +24,7 @@ All supported models are hosted under the [`inference4j`](https://huggingface.co
 
 | Capability | Wrapper | Default Model ID | Size | API |
 |------------|---------|-------------------|------|-----|
-| Zero-Shot Classification | `ClipClassifier` | `inference4j/clip-vit-base-patch32` | ~595 MB | `ImageClassifier` |
+| Zero-Shot Classification | `ClipClassifier` | `inference4j/clip-vit-base-patch32` | ~595 MB | `ZeroShotClassifier` |
 | Image Embeddings | `ClipImageEncoder` | `inference4j/clip-vit-base-patch32` | ~340 MB | `ImageEmbedder` |
 | Text Embeddings (CLIP) | `ClipTextEncoder` | `inference4j/clip-vit-base-patch32` | ~255 MB | `TextEmbedder` |
 

--- a/inference4j-core/src/main/java/io/github/inference4j/ZeroShotClassifier.java
+++ b/inference4j-core/src/main/java/io/github/inference4j/ZeroShotClassifier.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.inference4j;
+
+import java.util.List;
+
+/**
+ * An inference task that classifies an input against arbitrary candidate labels
+ * provided at inference time (zero-shot classification).
+ *
+ * <p>Unlike {@link Classifier}, which classifies against a fixed set of categories
+ * baked into the model, {@code ZeroShotClassifier} accepts candidate labels per call.
+ * This is the natural API for models like CLIP where classification labels are
+ * encoded at inference time rather than at training time.
+ *
+ * @param <I> the primary input type (e.g., {@code BufferedImage})
+ * @param <C> the classification result type (e.g., {@code Classification})
+ */
+public interface ZeroShotClassifier<I, C> extends InferenceTask<ZeroShotInput<I>, List<C>> {
+
+    /**
+     * Classifies the input against the given candidate labels.
+     *
+     * @param input           the input to classify
+     * @param candidateLabels the text labels to classify against
+     * @return scored classifications, typically sorted by confidence descending
+     */
+    List<C> classify(I input, List<String> candidateLabels);
+
+    @Override
+    default List<C> run(ZeroShotInput<I> input) {
+        return classify(input.input(), input.candidateLabels());
+    }
+}

--- a/inference4j-core/src/main/java/io/github/inference4j/ZeroShotInput.java
+++ b/inference4j-core/src/main/java/io/github/inference4j/ZeroShotInput.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.inference4j;
+
+import java.util.List;
+
+/**
+ * Compound input for zero-shot classification — combines the primary input
+ * with candidate labels to classify against.
+ *
+ * @param input           the primary input (e.g., an image)
+ * @param candidateLabels the text labels to classify against
+ * @param <I>             the primary input type
+ */
+public record ZeroShotInput<I>(I input, List<String> candidateLabels) {
+}

--- a/inference4j-core/src/main/java/io/github/inference4j/processing/MathOps.java
+++ b/inference4j-core/src/main/java/io/github/inference4j/processing/MathOps.java
@@ -233,6 +233,23 @@ public final class MathOps {
     }
 
     /**
+     * Computes the dot product of two vectors.
+     *
+     * @throws IllegalArgumentException if the vectors have different lengths
+     */
+    public static float dotProduct(float[] a, float[] b) {
+        if (a.length != b.length) {
+            throw new IllegalArgumentException(
+                    "Vectors must have the same length: " + a.length + " vs " + b.length);
+        }
+        float sum = 0f;
+        for (int i = 0; i < a.length; i++) {
+            sum += a[i] * b[i];
+        }
+        return sum;
+    }
+
+    /**
      * L2-normalizes a vector so that its Euclidean norm equals 1.
      * Returns a zero vector if the input norm is zero.
      */

--- a/inference4j-core/src/test/java/io/github/inference4j/processing/MathOpsTest.java
+++ b/inference4j-core/src/test/java/io/github/inference4j/processing/MathOpsTest.java
@@ -386,6 +386,32 @@ class MathOpsTest {
     }
 
     @Test
+    void dotProduct_identicalNormalizedVectors_returnsOne() {
+        float[] v = MathOps.l2Normalize(new float[]{3f, 4f});
+        assertEquals(1.0f, MathOps.dotProduct(v, v), 1e-5f);
+    }
+
+    @Test
+    void dotProduct_orthogonalVectors_returnsZero() {
+        float[] a = {1f, 0f};
+        float[] b = {0f, 1f};
+        assertEquals(0f, MathOps.dotProduct(a, b), 1e-6f);
+    }
+
+    @Test
+    void dotProduct_oppositeVectors_returnsNegativeOne() {
+        float[] a = MathOps.l2Normalize(new float[]{1f, 0f});
+        float[] b = MathOps.l2Normalize(new float[]{-1f, 0f});
+        assertEquals(-1.0f, MathOps.dotProduct(a, b), 1e-5f);
+    }
+
+    @Test
+    void dotProduct_mismatchedLengths_throws() {
+        assertThrows(IllegalArgumentException.class, () ->
+                MathOps.dotProduct(new float[]{1f, 2f}, new float[]{1f}));
+    }
+
+    @Test
     void cxcywh2xyxy_basicConversion() {
         // center=(50,50), size=20x30 → x1=40, y1=35, x2=60, y2=65
         float[] boxes = {50f, 50f, 20f, 30f};

--- a/inference4j-tasks/src/modelTest/java/io/github/inference4j/multimodal/ClipClassifierModelTest.java
+++ b/inference4j-tasks/src/modelTest/java/io/github/inference4j/multimodal/ClipClassifierModelTest.java
@@ -34,14 +34,15 @@ class ClipClassifierModelTest {
 
     @Test
     void classify_catImage_catIsTopLabel() throws IOException {
-        try (ClipClassifier classifier = ClipClassifier.builder()
-                .labels("cat", "dog", "bird", "car", "airplane")
-                .build()) {
-            List<Classification> results = classifier.classify(loadCatImage());
+        try (ClipClassifier classifier = ClipClassifier.builder().build()) {
+            List<Classification> results = classifier.classify(
+                    loadCatImage(),
+                    List.of("a photo of a cat", "a photo of a dog", "a photo of a bird",
+                            "a photo of a car", "a photo of an airplane"));
 
             assertFalse(results.isEmpty());
-            assertEquals("cat", results.get(0).label(),
-                    "Expected 'cat' as top label, got: " + results.get(0).label());
+            assertEquals("a photo of a cat", results.get(0).label(),
+                    "Expected 'a photo of a cat' as top label, got: " + results.get(0).label());
             assertTrue(results.get(0).confidence() > 0.15f,
                     "Expected cat confidence > 0.15, got: " + results.get(0).confidence());
         }
@@ -49,10 +50,10 @@ class ClipClassifierModelTest {
 
     @Test
     void classify_catImage_confidencesSumToOne() throws IOException {
-        try (ClipClassifier classifier = ClipClassifier.builder()
-                .labels("cat", "dog", "bird")
-                .build()) {
-            List<Classification> results = classifier.classify(loadCatImage());
+        try (ClipClassifier classifier = ClipClassifier.builder().build()) {
+            List<Classification> results = classifier.classify(
+                    loadCatImage(),
+                    List.of("a photo of a cat", "a photo of a dog", "a photo of a bird"));
 
             float sum = 0f;
             for (Classification c : results) {
@@ -65,25 +66,14 @@ class ClipClassifierModelTest {
 
     @Test
     void classify_catImage_withTopK() throws IOException {
-        try (ClipClassifier classifier = ClipClassifier.builder()
-                .labels("cat", "dog", "bird", "car", "airplane")
-                .build()) {
-            List<Classification> results = classifier.classify(loadCatImage(), 2);
+        try (ClipClassifier classifier = ClipClassifier.builder().build()) {
+            List<Classification> results = classifier.classify(
+                    loadCatImage(),
+                    List.of("a photo of a cat", "a photo of a dog", "a photo of a bird",
+                            "a photo of a car", "a photo of an airplane"),
+                    2);
 
             assertEquals(2, results.size());
-        }
-    }
-
-    @Test
-    void classify_catImage_customPromptTemplate() throws IOException {
-        try (ClipClassifier classifier = ClipClassifier.builder()
-                .labels("cat", "dog", "bird")
-                .promptTemplate("this is a picture of a {}")
-                .build()) {
-            List<Classification> results = classifier.classify(loadCatImage());
-
-            assertEquals("cat", results.get(0).label(),
-                    "Custom prompt template should still identify cat");
         }
     }
 }


### PR DESCRIPTION
## Summary

- Introduces `ZeroShotClassifier<I, C>` interface and `ZeroShotInput<I>` record in `inference4j-core` for zero-shot classification with per-call candidate labels
- Redesigns `ClipClassifier` to implement `ZeroShotClassifier<BufferedImage, Classification>` instead of `ImageClassifier`, removing build-time `labels`, `promptTemplate`, and `defaultTopK` — labels are now passed per `classify()` call
- Extracts `MathOps.dotProduct()` from ClipClassifier's private `dot()` method into a public utility with length validation

## Test plan

- [x] `./gradlew :inference4j-core:test` — MathOps dotProduct tests pass
- [x] `./gradlew :inference4j-tasks:test` — ClipClassifier unit tests pass with new per-call API
- [x] `./gradlew build` — full build passes, no dangling references to old API
- [ ] `./gradlew :inference4j-tasks:modelTest` — verify real CLIP model inference with per-call labels