### PR TITLE
Pin onnxruntime to 1.23.0 to align with onnxruntime-genai

### DIFF
--- a/inference4j-core/build.gradle
+++ b/inference4j-core/build.gradle
@@ -1,5 +1,5 @@
 description = 'Low-level ONNX Runtime abstractions for inference4j'
 
 dependencies {
-    api 'com.microsoft.onnxruntime:onnxruntime:1.23.2'
+    api 'com.microsoft.onnxruntime:onnxruntime:1.23.0'
 }


### PR DESCRIPTION
## Summary

- Pins `com.microsoft.onnxruntime:onnxruntime` from 1.23.2 to 1.23.0 in `inference4j-core`
- Fixes native library conflict when `inference4j-genai` and `inference4j-core` are on the same classpath

## Problem

The `onnxruntime-genai:0.12.0` JAR bundles `libonnxruntime` 1.23.0 native libraries at `ai/onnxruntime/native/`. When `inference4j-core` pulls in `onnxruntime:1.23.2`, both JARs have the same resource path but different versions. The classloader may resolve the 1.23.0 copy, causing the 1.23.2 JNI bridge to fail with:

```
Library not loaded: @rpath/libonnxruntime.1.23.2.dylib
```

## Fix

Pin to 1.23.0 so both JARs carry the same native library version. This is a stopgap — the proper fix is to exclude `ai/onnxruntime/native/` from the `onnxruntime-genai` fat JAR so it doesn't shadow the standalone dependency.

## Test plan

- [ ] `./gradlew build` passes
- [ ] Showcase app with both `inference4j-spring-boot-starter` and `inference4j-genai` starts without `UnsatisfiedLinkError`
- [ ] Existing inference tasks (classification, detection, etc.) still work
- [ ] Text generation via `TextGenerator` works