### PR TITLE
Refresh onnxruntime-genai shadow build to 0.15.2

### DIFF
--- a/docs/generative-ai/introduction.md
+++ b/docs/generative-ai/introduction.md
@@ -34,7 +34,7 @@ inference4j implements the full autoregressive loop in Java on top of standard O
 **Cons:**
 
 - Models must be exported in onnxruntime-genai's specific format — few are available today
-- The library is in preview and community support is limited; Microsoft's investment appears to have slowed
+- The library is still in preview and community support is limited
 - Requires a separate native dependency (`onnxruntime-genai`) that we build and publish ourselves since Microsoft does not currently publish Java bindings to Maven Central
 - GPU support is not available in the Java bindings
 
@@ -43,6 +43,25 @@ inference4j implements the full autoregressive loop in Java on top of standard O
     The `inference4j-genai` module wraps a library in preview. We maintain the
     [onnxruntime-genai Java build](https://github.com/inference4j/onnxruntime-genai)
     ourselves. The API may change between releases.
+
+### Versions
+
+`inference4j-genai` tracks upstream onnxruntime-genai releases through our shadow
+build, published as `io.github.inference4j:onnxruntime-genai`:
+
+| inference4j | onnxruntime-genai | ONNX Runtime |
+|-------------|-------------------|--------------|
+| 0.10.1      | 0.15.2            | 1.26.0       |
+| 0.10.0      | 0.12.0            | 1.23.0       |
+
+!!! note "Keep ONNX Runtime versions aligned"
+
+    The shadow build ships a fat JAR that bundles ONNX Runtime's native libraries
+    under the same resource path (`ai/onnxruntime/native/`) that the official
+    `com.microsoft.onnxruntime:onnxruntime` JAR uses. `inference4j-core` therefore
+    pins the ONNX Runtime version the genai natives were built against. If you
+    override the ONNX Runtime version yourself, keep it matched to the table above
+    — otherwise which native library gets loaded depends on classpath order.
 
 ### Where we're heading
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - **Java 17** or higher
-- ONNX Runtime (included transitively)
+- ONNX Runtime 1.26.0 (included transitively via `inference4j-core`)
 
 ## Add the dependency
 
@@ -45,6 +45,14 @@ For text generation (Phi-3, DeepSeek-R1, etc.), add `inference4j-genai` instead:
     ```
 
 This is a separate module backed by onnxruntime-genai. See the [Generative AI guide](../generative-ai/introduction.md) for details.
+
+!!! warning "Don't override the ONNX Runtime version alongside `inference4j-genai`"
+
+    `inference4j-genai` pulls in a fat JAR that bundles ONNX Runtime's native
+    libraries under the same resource path the official ONNX Runtime JAR uses.
+    `inference4j-core` pins the version those natives were built against, so
+    forcing a different ONNX Runtime version can silently load the wrong native
+    library. See [Generative AI &rarr; Versions](../generative-ai/introduction.md#versions).
 
 ## JVM flags
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -89,6 +89,16 @@
 - [x] **Cased tokenizer** — `WordPieceTokenizer.fromVocabFile(path, lowercase)` for cased models
 - [x] Spring Boot auto-configuration for `NamedEntityRecognizer`
 
+### v0.10.1 — Dependency refresh
+
+- [x] **onnxruntime-genai 0.12.0 &rarr; 0.15.2** — refreshed our
+      [shadow build](https://github.com/inference4j/onnxruntime-genai); picks up upstream
+      security fixes and Gemma 4 / int8 support
+- [x] **ONNX Runtime 1.23.0 &rarr; 1.26.0** — matches the version the genai natives are
+      built against, so both modules load the same native library
+- [x] Documented the ONNX Runtime version contract between `inference4j-core` and
+      `inference4j-genai`
+
 ## Next Up
 
 ### v0.11.0 — Tiktoken & LLM Support

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.10.0
+version=0.10.1

--- a/inference4j-core/build.gradle
+++ b/inference4j-core/build.gradle
@@ -1,7 +1,7 @@
 description = 'Low-level ONNX Runtime abstractions for inference4j'
 
 dependencies {
-    api 'com.microsoft.onnxruntime:onnxruntime:1.23.0'
+    api 'com.microsoft.onnxruntime:onnxruntime:1.26.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.3'
 }
 

--- a/inference4j-genai/build.gradle
+++ b/inference4j-genai/build.gradle
@@ -1,7 +1,7 @@
 description = 'Autoregressive generation wrappers for inference4j via onnxruntime-genai'
 
 dependencies {
-    api 'io.github.inference4j:onnxruntime-genai:0.12.0'
+    api 'io.github.inference4j:onnxruntime-genai:0.15.2'
     implementation project(':inference4j-core')
     runtimeOnly 'org.slf4j:slf4j-nop:2.0.16'
 }


### PR DESCRIPTION
Refreshes our [onnxruntime-genai shadow build](https://github.com/inference4j/onnxruntime-genai) from 0.12.0 (Feb 2026) to 0.15.2, and moves ONNX Runtime to the version those natives are built against.

## What changed

| | Before | After |
|---|---|---|
| `onnxruntime-genai` | 0.12.0 | 0.15.2 |
| `onnxruntime` | 1.23.0 | 1.26.0 |
| `version` | 0.10.0 | 0.10.1 |

Upstream shipped four releases while we sat on 0.12.0 — 0.13.x, 0.14.0 and 0.15.x — including fixes for a use-after-free and a heap overflow, Gemma 4 per-layer inputs, and int8 precision support.

## Why ONNX Runtime moves too

This is not housekeeping. The genai fat JAR bundles ONNX Runtime's native libraries under `ai/onnxruntime/native/<platform>/` — the same resource path used by `com.microsoft.onnxruntime:onnxruntime`. So `inference4j-core` and `inference4j-genai` each put a `libonnxruntime` on the classpath and the first one found wins.

The genai POM declares no dependencies at all (its release build publishes `allJar` rather than `from components.java`), so neither Gradle nor Maven can resolve this for us. Pinning `inference4j-core` to the version the genai natives were linked against keeps both copies identical.

This is also why this PR stops at 1.26.0 rather than 1.29.0. Jumping core to 1.29 would break that alignment, since the genai natives are 1.26. Moving to 1.29 means moving both sides together, and it additionally needs rework for ONNX Runtime's new plugin execution providers (CUDA is a separately packaged EP as of 1.29) — that belongs in its own change.

## Shadow build side

Published from [inference4j/onnxruntime-genai@v0.15.2](https://github.com/inference4j/onnxruntime-genai/tree/v0.15.2). Two things needed fixing there beyond the version rebase:

- Upstream reworked `src/java/build.gradle` between 0.12.0 and 0.15.2, so the overlay needed re-applying rather than a clean cherry-pick.
- The release workflow's Windows job broke on environment drift: `windows-latest` is now the `windows-2025-vs2026` image, so the `Visual Studio 17 2022` CMake generator finds no toolchain. Moved to `Visual Studio 18 2026`, dropped the stale `vs-version: '17.5'` pin, and set `fail-fast: false` so all three platforms report.

Verified the published JAR carries 13 native libraries — genai plus ONNX Runtime 1.26.0 — for linux-x64, osx-aarch64 and win-x64.

## Docs

- Version table and the ONNX Runtime version contract in the Generative AI guide
- Matching warning on the installation page against overriding the ONNX Runtime version
- Roadmap entry for v0.10.1

`mkdocs build --strict` passes and the new cross-page anchor resolves.

## Testing

`./gradlew build` green across all modules against the published 0.15.2 artifact.
