### PR TITLE
Document plugin execution providers

### DIFF
--- a/docs/guides/hardware-acceleration.md
+++ b/docs/guides/hardware-acceleration.md
@@ -58,6 +58,66 @@ try (var classifier = ResNetClassifier.builder()
 }
 ```
 
+## Plugin execution providers
+
+ONNX Runtime can also load execution providers from **separately packaged plugin libraries**, rather than only the ones compiled into the runtime. Microsoft ships several this way — the CUDA and WebGPU plugin EPs, for example — versioned independently of ONNX Runtime itself.
+
+This is additive. `addCoreML()` and `addCUDA()` above are unaffected and remain the simplest path. Reach for a plugin EP when you need a backend that isn't built into your ONNX Runtime distribution.
+
+### Register the plugin library
+
+Registration happens on the `OrtEnvironment`, not on the session. inference4j uses ONNX Runtime's default environment, so anything you register there applies to every model you build afterwards:
+
+```java
+OrtEnvironment env = OrtEnvironment.getEnvironment();
+env.registerExecutionProviderLibrary("my_ep", "/path/to/plugin_ep_library.so");
+```
+
+### Pick devices and attach them
+
+`getEpDevices()` lists every execution provider / device combination available, including ones contributed by registered plugins. Filter down to the provider you want, then pass the result to `addExecutionProvider`:
+
+```java
+OrtEnvironment env = OrtEnvironment.getEnvironment();
+
+List<OrtEpDevice> devices = env.getEpDevices().stream()
+        .filter(d -> "my_ep".equals(d.getEpName()))
+        .toList();
+
+try (var classifier = ResNetClassifier.builder()
+        .sessionOptions(opts -> opts.addExecutionProvider(devices, Map.of()))
+        .build()) {
+    classifier.classify(Path.of("cat.jpg"));
+}
+```
+
+Two rules worth knowing:
+
+- Every `OrtEpDevice` in the list must belong to the **same** execution provider, though they may point at different devices.
+- Providers apply **in the order added** — the first provider added gets first choice when graph nodes are assigned.
+
+### Inspect what's available
+
+`OrtEpDevice` exposes `getEpName()`, `getEpVendor()`, `getEpMetadata()`, `getEpOptions()` and `getDevice()`, which is enough to see what a machine actually offers:
+
+```java
+for (OrtEpDevice d : OrtEnvironment.getEnvironment().getEpDevices()) {
+    System.out.println(d.getEpName() + " (" + d.getEpVendor() + ") -> " + d.getDevice());
+}
+```
+
+To remove a plugin again:
+
+```java
+env.unregisterExecutionProviderLibrary("my_ep");
+```
+
+!!! note "Requires ONNX Runtime 1.24.3 or later"
+
+    `registerExecutionProviderLibrary()`, `getEpDevices()` and `addExecutionProvider()` are not
+    present in 1.23. inference4j depends on ONNX Runtime 1.26.0 as of 0.10.1, so they are
+    available with no extra setup.
+
 ## The `sessionOptions` API
 
 Every model wrapper exposes `.sessionOptions(SessionConfigurer)` in its builder. `SessionConfigurer` is a `@FunctionalInterface` that receives the ONNX Runtime `SessionOptions`:
@@ -84,6 +144,7 @@ This gives you full access to ONNX Runtime configuration:
 |--------|-------------|
 | `opts.addCoreML()` | Enable CoreML (macOS) |
 | `opts.addCUDA(deviceId)` | Enable CUDA (Linux/Windows) |
+| `opts.addExecutionProvider(devices, options)` | Enable a [plugin execution provider](#plugin-execution-providers) |
 | `opts.setIntraOpNumThreads(n)` | Set number of threads for intra-op parallelism |
 | `opts.setInterOpNumThreads(n)` | Set number of threads for inter-op parallelism |
 | `opts.setOptimizationLevel(level)` | Set graph optimization level |


### PR DESCRIPTION
ONNX Runtime has an API for loading execution providers from separately packaged plugin libraries. We have shipped it since v0.10.1 moved us to ONNX Runtime 1.26.0, but never documented it.

## What this adds

A `Plugin execution providers` section in `docs/guides/hardware-acceleration.md` covering:

- Registering a plugin library via `OrtEnvironment.registerExecutionProviderLibrary()`
- Listing and filtering `getEpDevices()`, then attaching them with `addExecutionProvider()` through the existing `.sessionOptions()` lambda
- Inspecting what a machine offers via `OrtEpDevice`
- Unregistering

Plus a row in the common options table linking to it.

## Points verified against the ONNX Runtime 1.29 Java sources

- **The API is additive.** `addCoreML()` and `addCUDA(int)` still exist and are **not** deprecated in 1.29, and the public API of `OrtSession` and `OrtEnvironment` is byte-identical between 1.26.0 and 1.29.0. The section frames plugin EPs as being for backends not built into your ONNX Runtime distribution, not as a migration target.
- **Registration actually reaches inference4j.** It happens on `OrtEnvironment`, not the session. `InferenceSession` uses `OrtEnvironment.getEnvironment()`, the same default singleton `addExecutionProvider` resolves internally, so a registration applies to every model built afterwards. Had we used a private environment the whole section would have been wrong.
- **The version floor is 1.24.3**, not 1.26 — the API is present in 1.24.3 and absent in 1.24.0. The note states the real floor rather than just the version we happen to depend on.

## Testing

`mkdocs build --strict` passes; the new anchor resolves from the options table.

Docs only, so no version bump.