### PR TITLE
Move the Spring Boot starter to Spring Boot 4

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -82,7 +82,9 @@ tasks.withType(Test).configureEach {
 
 ## Spring Boot
 
-For Spring Boot applications, use the starter instead:
+For Spring Boot applications, use the starter instead. It requires **Spring Boot 4.0 or
+later** as of inference4j 0.11.0 — see the [Spring Boot guide](../guides/spring-boot.md#requirements)
+if you are still on Boot 3.
 
 === "Gradle"
 

--- a/docs/guides/spring-boot.md
+++ b/docs/guides/spring-boot.md
@@ -2,6 +2,30 @@
 
 inference4j provides a Spring Boot starter with opt-in auto-configuration for all supported models.
 
+## Requirements
+
+| | |
+|---|---|
+| **Spring Boot** | 4.0 or later |
+| **Spring Framework** | 7.0 or later |
+| **Java** | 17 or later |
+
+!!! warning "Spring Boot 4 required as of inference4j 0.11.0"
+
+    The starter targets Spring Boot 4. It will not load in a Spring Boot 3
+    application — Boot 4 relocated the actuator health types, so the two lines are
+    binary-incompatible and cannot be served by one artifact.
+
+    If you are still on Spring Boot 3, stay on
+    **`inference4j-spring-boot-starter:0.10.1`**, which is the last release built
+    against Boot 3.4. It is frozen, not maintained — Spring Boot 3.x itself left
+    open-source support on 30 June 2026, so migrating to Boot 4 is the recommended
+    path. See [Migrating from 0.10.x](#migrating-from-010x) below.
+
+    Only the starter is affected. `inference4j-core` and every other module are
+    plain Java libraries with no Spring dependency, and work unchanged on any
+    Spring version or none at all.
+
 ## Setup
 
 Add the starter dependency:
@@ -193,6 +217,65 @@ public class ModelWarmup {
 ```
 
 This triggers the lazy bean initialization during startup, so the model is ready when the first real request arrives.
+
+## Migrating from 0.10.x
+
+inference4j 0.11.0 moved the starter from Spring Boot 3 to Spring Boot 4. There is no
+Boot 3 branch — 0.10.1 is the last Boot 3 release and stays available on Maven Central.
+
+**1. Upgrade your application to Spring Boot 4.** Spring's own
+[migration guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide)
+recommends going to 3.5 first, then to 4.0. Boot 4 requires Java 17 or later.
+
+**2. Update the health indicator import, if you override it.** The actuator health types
+moved modules in Boot 4. If you replace inference4j's default indicator with your own bean,
+change:
+
+```java
+// Before (Spring Boot 3)
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+
+// After (Spring Boot 4)
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+```
+
+The interface itself is unchanged — `HealthIndicator` is still a `@FunctionalInterface`
+returning `Health`, so an existing lambda keeps working once the import is fixed.
+
+**3. Nothing else changes.** Every `inference4j.*` property, bean name and default is
+identical to 0.10.x. If you do not override the health indicator, upgrading your Boot
+version is the only step.
+
+### If you cannot move to Spring Boot 4 yet
+
+Pin the starter to the last Boot 3 release and let it float independently of the rest:
+
+=== "Gradle"
+
+    ```groovy
+    implementation 'io.github.inference4j:inference4j-spring-boot-starter:0.10.1'
+    implementation 'io.github.inference4j:inference4j-core:${inference4jVersion}'
+    ```
+
+=== "Maven"
+
+    ```xml
+    <dependency>
+        <groupId>io.github.inference4j</groupId>
+        <artifactId>inference4j-spring-boot-starter</artifactId>
+        <version>0.10.1</version>
+    </dependency>
+    <dependency>
+        <groupId>io.github.inference4j</groupId>
+        <artifactId>inference4j-core</artifactId>
+        <version>${inference4jVersion}</version>
+    </dependency>
+    ```
+
+`inference4j-core` has no Spring dependency, so you can keep it current while the starter
+stays pinned. The 0.10.1 starter will not receive fixes.
 
 ## Tips
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -99,17 +99,54 @@
 - [x] Documented the ONNX Runtime version contract between `inference4j-core` and
       `inference4j-genai`
 
+### v0.11.0 — Spring Boot 4
+
+- [x] **Spring Boot 4 starter** — the starter now targets Spring Boot 4.0+ / Spring Framework 7
+- [x] Actuator health types moved to `org.springframework.boot.health.contributor`
+- [x] [Migration guide](guides/spring-boot.md#migrating-from-010x) for existing users
+
+Spring Boot 3.x left open-source support on 30 June 2026, and Spring AI 2.0 (GA June 2026)
+requires Boot 4 and cannot load in a 3.x context. Boot 4 is also binary-incompatible with
+Boot 3 for the actuator health types the starter uses, so a single artifact cannot serve
+both — 0.10.1 is the final Boot 3 release and remains on Maven Central, frozen.
+
+Only the starter is affected. `inference4j-core` and every other module have no Spring
+dependency.
+
 ## Next Up
 
-### v0.11.0 — Tiktoken & LLM Support
+### Tokenizers & LLMs
 
-- [ ] **Tiktoken tokenizer** — `cl100k_base` / `o200k_base` encoding for OpenAI-family models
-- [ ] At least one LLM that uses Tiktoken (e.g., Llama 3, Phi-4)
+- [ ] **Tiktoken tokenizer** — deferred. No small, ONNX-viable model currently requires it;
+      the realistic near-term targets use byte-level BPE or SentencePiece Unigram, both of
+      which are already implemented. Revisit when a concrete model needs it.
 
-### v0.12.0 — Text-to-Speech
+### Speech
 
-- [ ] **Piper TTS** — text-to-speech via Piper ONNX models
+- [ ] **Moonshine speech-to-text** — raw-waveform ASR (MIT, 27M/62M) that performs feature
+      extraction inside the ONNX graph, so it needs no mel-spectrogram/FFT work in Java.
+      Reuses the existing raw-waveform audio pipeline.
+
+### Embeddings & reranking
+
+- [ ] **Qwen3-Embedding / Qwen3-Reranker (0.6B)** — Apache 2.0 with existing ONNX exports.
+      Uses byte-level BPE we already support; the reranker scores via decoder tokens rather
+      than a cross-encoder head, so it needs a new `OutputOperator`.
+
+### Text-to-Speech
+
+- [ ] **Kokoro TTS** — replaces Piper as the TTS target. Apache 2.0 end to end, versus
+      Piper's development having moved to a GPL-3.0 fork.
+- [ ] **Java phonemizer** — Kokoro needs grapheme-to-phoneme conversion, and the usual
+      fallback (espeak-ng) is GPL-3.0. Needs a dictionary-based phonemizer over a
+      permissively licensed lexicon. This is the real cost of the TTS milestone.
 - [ ] `SpeechSynthesizer` interface, audio output generation
+
+### Pixel-level tasks
+
+- [ ] **`Tensor.toFloats3D()` + tensor-to-image utility** — one prerequisite unlocking depth
+      estimation (Depth Anything V2), semantic segmentation (SegFormer) and super-resolution
+      (Real-ESRGAN)
 
 ### Beyond
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.10.1
+version=0.11.0

--- a/inference4j-spring-boot-starter/build.gradle
+++ b/inference4j-spring-boot-starter/build.gradle
@@ -1,7 +1,7 @@
 description = 'Spring Boot starter for inference4j'
 
 ext {
-    springBootVersion = '3.4.2'
+    springBootVersion = '4.1.1'
 }
 
 dependencies {

--- a/inference4j-spring-boot-starter/src/main/java/io/github/inference4j/autoconfigure/Inference4jHealthAutoConfiguration.java
+++ b/inference4j-spring-boot-starter/src/main/java/io/github/inference4j/autoconfigure/Inference4jHealthAutoConfiguration.java
@@ -20,12 +20,12 @@ import java.util.List;
 import io.github.inference4j.InferenceTask;
 
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.context.annotation.Bean;
 
 /**

--- a/inference4j-spring-boot-starter/src/test/java/io/github/inference4j/autoconfigure/Inference4jHealthAutoConfigurationTest.java
+++ b/inference4j-spring-boot-starter/src/test/java/io/github/inference4j/autoconfigure/Inference4jHealthAutoConfigurationTest.java
@@ -18,10 +18,10 @@ package io.github.inference4j.autoconfigure;
 import io.github.inference4j.InferenceTask;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.boot.health.contributor.Status;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;


### PR DESCRIPTION
Targets **Spring Boot 4.0+ / Spring Framework 7**. `0.10.1` becomes the frozen final Boot 3 release.

## Why now

- **Spring Boot 3.x is off open-source support.** 3.4 ended 31 Dec 2025, 3.5 ended 30 Jun 2026. The starter was compiling against 3.4.2 — nine months past EOL.
- **Spring AI 2.0 went GA on 12 June 2026** and requires Boot 4.0/4.1 with Framework 7. It cannot load in a 3.x context, so the starter's Boot version gates every future Spring AI integration.
- **One artifact cannot serve both lines.** Spring's own migration guide calls supporting Boot 3 and 4 from a single jar "strongly discouraged", and the actuator health types this starter uses moved modules.

## What actually changed

Smaller than the framing suggests — three imports:

```
org.springframework.boot.actuate.health.{Health, HealthIndicator, Status}
  → org.springframework.boot.health.contributor.{Health, HealthIndicator, Status}
```

`HealthIndicator` is still a `@FunctionalInterface` whose abstract method is `Health health()`, so the existing lambda compiles unchanged. Boot 4's `getHealth(boolean)` → `health(boolean)` rename affects only a **default** method this code never implemented.

Plus `springBootVersion` `3.4.2` → `4.1.1` and the version bump to `0.11.0`.

## Verified unchanged, rather than assumed

Checked against the Spring Boot 4 sources directly:

| | Status |
|---|---|
| `@AutoConfiguration`, `@ConditionalOn*` | packages unchanged (`core/spring-boot-autoconfigure`) |
| `@ConfigurationProperties`, `@EnableConfigurationProperties` | unchanged (`core/spring-boot`) |
| `ApplicationContextRunner` | unchanged (`core/spring-boot-test`) |
| `META-INF/spring/...AutoConfiguration.imports` | path identical |
| Minimum Java | 17 — toolchain untouched |

Only the starter is affected. `inference4j-core` and every other module are plain Java with no Spring dependency, and work on any Spring version or none.

## Docs

- Requirements table and a Boot 4 warning on the Spring Boot guide
- A **Migrating from 0.10.x** section, including how to pin the starter to 0.10.1 while keeping `inference4j-core` current
- Roadmap: v0.11.0 recorded, and Next Up resequenced from the ecosystem review — Tiktoken deferred (no small ONNX-viable model requires it), Moonshine / Qwen3-Embedding / Kokoro added

## Testing

`./gradlew build` green across all modules against Boot 4.1.1. `mkdocs build --strict` passes with all new anchors resolving.

Known cosmetic issue: 3 `unknown enum constant Include.NON_EMPTY` warnings on test compile, because Boot 4's `Health` carries deprecated Jackson 2 annotations not on the test classpath. Harmless; can be silenced with a test-scoped `jackson-annotations` if we want a clean log.